### PR TITLE
Add chart type examples to data ops

### DIFF
--- a/03_nyc311/m-nyc311.yml
+++ b/03_nyc311/m-nyc311.yml
@@ -1,6 +1,7 @@
 glean: "1.0"
 type: model
 name: NYC 311
+grn: m:b76d1af8-69c3-3870-bdd2-46cdb2cc14df
 source:
   connectionName: bigquery-template
   sql: >-

--- a/03_nyc311/saved_views/area_chart.yml
+++ b/03_nyc311/saved_views/area_chart.yml
@@ -1,0 +1,21 @@
+glean: "1.0"
+type: saved_view
+model: m:b76d1af8-69c3-3870-bdd2-46cdb2cc14df
+name: Cumulative Call Volume Metrics Over Time 
+data:
+  x:
+    columnId: created_date
+    granularity: quarter
+  y:
+    - columnId: row_count
+    - name: Rolling Sum over call volume
+      formula: rollingSum(row_count, 4, trailing, 0)
+    - name: Rolling Average over call volume
+      formula: rollingAverage(row_count, 4, trailing, 0)
+  breakout:
+    by: metric
+  filters: []
+visualization:
+  chartType: area
+  stack: stack
+  showAxisLabels: true

--- a/03_nyc311/saved_views/bar_chart.yml
+++ b/03_nyc311/saved_views/bar_chart.yml
@@ -1,0 +1,15 @@
+glean: "1.0"
+type: saved_view
+model: m:b76d1af8-69c3-3870-bdd2-46cdb2cc14df
+name: Call Volume Over Time
+data:
+  x:
+    columnId: created_date
+    granularity: quarter
+  y:
+    columnId: row_count
+  filters: []
+visualization:
+  chartType: bar
+  showAxisLabels: true
+  missingValuesBehavior: show

--- a/03_nyc311/saved_views/horizontal_bar.yml
+++ b/03_nyc311/saved_views/horizontal_bar.yml
@@ -1,0 +1,18 @@
+glean: "1.0"
+type: saved_view
+model: m:b76d1af8-69c3-3870-bdd2-46cdb2cc14df
+name: Total Call Volume By Agency 
+data:
+  metric:
+    columnId: row_count
+  rows:
+    columnId: agency_name
+  filters: []
+  sort:
+    - columnId: row_count
+      order: desc
+  limit: 10000
+visualization:
+  chartType: horizontal_bar
+  showBarLabels: true
+  showAxisLabels: true

--- a/03_nyc311/saved_views/line_chart.yml
+++ b/03_nyc311/saved_views/line_chart.yml
@@ -1,0 +1,24 @@
+glean: "1.0"
+type: saved_view
+model: m:b76d1af8-69c3-3870-bdd2-46cdb2cc14df
+name: Call Volume By Agency
+data:
+  x:
+    columnId: created_date
+    granularity: quarter
+  y:
+    columnId: row_count
+  breakout:
+    columnId: agency_name
+    groups:
+      - key: New York City Police Department
+      - key: Department of Housing Preservation and Development
+      - key: Department of Transportation
+      - key: Department of Environmental Protection
+      - key: Department of Buildings
+      - key: Department of Parks and Recreation
+    showOther: true
+  filters: []
+visualization:
+  chartType: line
+  showAxisLabels: true

--- a/03_nyc311/saved_views/pivot_table.yml
+++ b/03_nyc311/saved_views/pivot_table.yml
@@ -1,0 +1,44 @@
+glean: "1.0"
+type: saved_view
+model: m:b76d1af8-69c3-3870-bdd2-46cdb2cc14df
+name: Call Volume by Day of Week and Agency
+data:
+  x:
+    columnId: day_of_week
+  y:
+    columnId: row_count
+  breakout:
+    columnId: agency_name
+    groups:
+      - key: New York City Police Department
+      - key: Department of Housing Preservation and Development
+      - key: Department of Transportation
+      - key: Department of Parks and Recreation
+      - key: Department of Sanitation
+    showOther: true
+  filters:
+    - columnId: location_type
+      excludeValues:
+        - null
+    - columnId: agency_name
+      values:
+        - New York City Police Department
+        - Department of Housing Preservation and Development
+        - Department of Transportation
+        - Department of Parks and Recreation
+        - Department of Sanitation
+        - Department of Health and Mental Hygiene
+  colSort:
+    - columnId: location_type
+      order: asc
+  rowSort:
+    - columnId: day_of_week
+      order: asc
+  limit: 10000
+visualization:
+  chartType: pivot
+  showAxisLabels: true
+  padding: compact
+  tableCellFormatting:
+    - color: green
+      calculation: columnPercentTotal

--- a/03_nyc311/saved_views/source_data_table.yml
+++ b/03_nyc311/saved_views/source_data_table.yml
@@ -1,0 +1,18 @@
+glean: "1.0"
+type: saved_view
+model: m:b76d1af8-69c3-3870-bdd2-46cdb2cc14df
+name: NYC 311 Source Data
+hidden:
+  - unique_key
+  - agency_name
+  - incident_zip
+data:
+  y:
+    columnId: row_count
+  filters:
+    - columnId: is_suspicious_timestamp
+      values:
+        - false
+  limit: 10000
+visualization:
+  chartType: source_data_table

--- a/03_nyc311/saved_views/table.yml
+++ b/03_nyc311/saved_views/table.yml
@@ -1,0 +1,46 @@
+glean: "1.0"
+type: saved_view
+model: m:b76d1af8-69c3-3870-bdd2-46cdb2cc14df
+name: Comparing Call Volume Metrics By Agency 
+data:
+  x:
+    columnId: agency_name
+  y:
+    - columnId: row_count
+    - columnId: avg_close_time_days
+  breakout:
+    columnId: location_type
+    groups:
+      - key: RESIDENTIAL BUILDING
+      - key: Street/Sidewalk
+      - key: Residential Building/House
+      - key: Street
+      - key: Sidewalk
+      - key: Store/Commercial
+    showOther: false
+  filters:
+    - columnId: location_type
+      excludeValues:
+        - null
+  sort:
+    - columnId: row_count
+      order: desc
+  limit: 10000
+visualization:
+  chartType: table
+  showAxisLabels: true
+  tableCellFormatting: []
+  tableVisualization:
+    - columnId: row_count
+      calculation: columnPercentTotal
+      type: bar
+      maxWidthPixels: 100
+      heightPixels: 15
+      labelPlacement: right
+  tableColumnWidths:
+    - columnId: row_count
+      width: 238
+    - columnId: avg_close_time_days
+      width: 183
+    - columnId: agency_name
+      width: 227


### PR DESCRIPTION
These are not the original saved views, just my interpretation of what they were based on the docs descriptions. 